### PR TITLE
feat: add device path support to reduce issues on non persistent device

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ You could use as many transmitters as you want. So, you can control more than 15
 In some special cases, you can configure every Elero USB Transmitter stick in your installation, add and setup the following settings to your `configuration.yaml` file to every stick:
 
 - **serial_number:**
-    - **description:** The serial number of the given Elero Transmitter Stick.
+    - **description:** The serial number of the given Elero Transmitter Stick. Required for automatic discovery, optional when using device_name.
+    - **required:** false (required for automatic discovery)
+    - **type:** string
+    - **default:** -
+- **device_path:**
+    - **description:** The device path to manually specify the serial port (e.g., /dev/ttyUSB0, /dev/ttyUSB2, COM1, etc.).
     - **required:** false
     - **type:** string
     - **default:** -
@@ -70,6 +75,9 @@ In some special cases, you can configure every Elero USB Transmitter stick in yo
 
 The connected Elero transmitters are automatically recognized and configured by HA automatically.
 The serial numbers of the connected transmitters can be found in the HA log and are needed for the further configuration. 
+
+**Note:** When using `device_path` to manually specify a device, the `serial_number` is still required for proper identification and channel mapping.
+
 Make sure you have the logger set to the INFO level to see the log message. You can do this by adding following to the config file `configuration.yaml`:
 
 ```yaml
@@ -96,6 +104,12 @@ Example of the configuration:
 elero:
     transmitters:
         - serial_number: 00000000
+          baudrate: 38400
+          bytesize: 8
+          parity: 'N'
+          stopbits: 1
+        - serial_number: B1234567
+          device_path: /dev/ttyUSB2
           baudrate: 38400
           bytesize: 8
           parity: 'N'

--- a/README_hass.md
+++ b/README_hass.md
@@ -46,7 +46,12 @@ elero:
 
 {% configuration %}
   serial_number:
-    description: Serial number if the given Transmitter Stick.
+    description: Serial number of the given Transmitter Stick. Required for automatic discovery, optional when using device_name.
+    required: false (required for automatic discovery)
+    type: string
+    default: -
+  device_path:
+    description: The device path to manually specify the serial port (e.g., /dev/serial/by-id/usb-Elero_Transmitter_Stick-if00, /dev/ttyUSB0, /dev/ttyUSB2, COM1, etc.).
     required: false
     type: string
     default: -
@@ -73,7 +78,7 @@ elero:
 {% endconfiguration %}
 
 
-The connected Elero transmitters are automatically recognized and set. The serial number of the given stick should be used to match a channel to the stick by you in the config file. You can find the serial numbers the HA log.
+The connected Elero transmitters are automatically recognized and set. The serial number of the given stick should be used to match a channel to the stick by you in the config file. You can find the serial numbers in the HA log.
 
 You can configure the connected devices with the followings in the `configuration.yaml` file if it is needed:
 
@@ -83,8 +88,15 @@ You can configure the connected devices with the followings in the `configuratio
 ```yaml
 # Example configuration.yaml entry
 elero:
-  serial_number: 00000000
-  baudrate: 9600
+  transmitters:
+    - serial_number: 00000000
+      baudrate: 9600
+    - serial_number: B1234567
+      device_path: /dev/serial/by-id/usb-Elero_Transmitter_Stick-if00
+      baudrate: 38400
+      bytesize: 8
+      parity: 'N'
+      stopbits: 1
 ```
 
 

--- a/config/elero.yaml
+++ b/config/elero.yaml
@@ -1,0 +1,43 @@
+# Example Elero configuration
+# This file shows how to configure Elero transmitters
+
+# Example 1: Automatic discovery (existing method)
+# The system will automatically find Elero devices and use their discovered serial numbers
+# transmitters:
+#   - serial_number: B1234567
+#     baudrate: 38400
+#     bytesize: 8
+#     parity: "N"
+#     stopbits: 1
+
+# Example 2: Manual device specification (new method)
+# You can manually specify the device path when automatic discovery doesn't work
+# or when you need to use a specific device
+# transmitters:
+#   - serial_number: B1234567
+#     device_path: /dev/ttyUSB2
+#     baudrate: 38400
+#     bytesize: 8
+#     parity: "N"
+#     stopbits: 1
+
+# Example 3: Multiple transmitters (recommended configuration)
+transmitters:
+  - baudrate: 38400
+    bytesize: 8
+    device_path: /dev/ttyUSB2
+    parity: "N"
+    serial_number: A908E04I
+    stopbits: 1
+  - baudrate: 38400
+    bytesize: 8
+    device_path: /dev/ttyUSB3
+    parity: "N"
+    serial_number: B1234567
+    stopbits: 1
+  - baudrate: 38400
+    bytesize: 8
+    parity: "N"
+    serial_number: C9876543
+    stopbits: 1
+    # No device_path - will use automatic discovery


### PR DESCRIPTION
Udev rules are not persistent on HA, device path name can change on every reboot. Being able to set from a device id path makes elero more reliable during restart/updates.

Note: I'm currently testing it, would be great if other person could test before merging. Thx